### PR TITLE
Updates are now batch

### DIFF
--- a/api.go
+++ b/api.go
@@ -43,6 +43,12 @@ func (a API) Push(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.Body == nil {
+		http.Error(w, "no body found", http.StatusBadRequest)
+
+		return
+	}
+
 	defer r.Body.Close()
 
 	body, err := ioutil.ReadAll(r.Body)
@@ -52,17 +58,19 @@ func (a API) Push(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	o := new(golo.Output)
+	ol := new([]golo.Output)
 
-	err = json.Unmarshal(body, o)
+	err = json.Unmarshal(body, ol)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 
 		return
 	}
 
-	a.OutputChan <- OutputMapper{
-		output:   *o,
-		database: index,
+	for _, o := range *ol {
+		a.OutputChan <- OutputMapper{
+			output:   o,
+			database: index,
+		}
 	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -13,13 +13,15 @@ func TestServeHTTP(t *testing.T) {
 		method       string
 		path         string
 		body         string
+		destroyBody  bool
 		expectStatus int
 	}{
-		{"valid request", "POST", "/push/blah", `{}`, 200},
-		{"path not found", "POST", "/hello", ``, 404},
-		{"invalid method", "PATCH", "/push/blah", ``, 405},
-		{"missing database", "POST", "/push/", `{}`, 404},
-		{"bad json", "POST", "/push/blah", "}}", 400},
+		{"valid request", "POST", "/push/blah", `[{}]`, false, 200},
+		{"path not found", "POST", "/hello", ``, false, 404},
+		{"invalid method", "PATCH", "/push/blah", ``, false, 405},
+		{"missing database", "POST", "/push/", `[{}]`, false, 404},
+		{"bad json", "POST", "/push/blah", "}}", false, 400},
+		{"malformed request body", "POST", "/push/blah", "", true, 400},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			a := API{make(chan OutputMapper)}
@@ -36,6 +38,10 @@ func TestServeHTTP(t *testing.T) {
 
 			r := httptest.NewRequest(test.method, u.String(), bytes.NewBufferString(test.body))
 			w := httptest.NewRecorder()
+
+			if test.destroyBody {
+				r.Body = nil
+			}
 
 			a.ServeHTTP(w, r)
 

--- a/main.go
+++ b/main.go
@@ -36,10 +36,12 @@ func main() {
 	go func() {
 		for o := range c {
 			for _, collector := range collectors {
-				err = collector.Push(o)
-				if err != nil {
-					log.Print(err)
-				}
+				go func() {
+					err = collector.Push(o)
+					if err != nil {
+						log.Print(err)
+					}
+				}()
 			}
 		}
 	}()


### PR DESCRIPTION
Allow for batch updates from agents to reduce workload. Additionally, return from `/push/*` calls as quick as possible