### PR TITLE
Use fasthttp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ services:
 language: go
 go:
   - "1.x"
-  - "1.8"
   - "1.10.x"
-  - master
 
 before_install:
   - make deps

--- a/main.go
+++ b/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"flag"
 	"log"
-	"net/http"
 
 	"github.com/go-lo/go-lo"
+	"github.com/valyala/fasthttp"
 )
 
 // OutputMapper includes a golo.Output and additional
@@ -50,5 +50,5 @@ func main() {
 		OutputChan: c,
 	}
 
-	panic(http.ListenAndServe(":8082", api))
+	panic(fasthttp.ListenAndServe(":8082", api.Route))
 }


### PR DESCRIPTION
Under load, collectors drop too many metrics. We are happy to drop *some* metrics, but we need to ensure the collector API is as efficient as possible